### PR TITLE
Add endpoints related to the Admin Console, and a few others

### DIFF
--- a/endpoints/POST/GetAdminStatusSummary.md
+++ b/endpoints/POST/GetAdminStatusSummary.md
@@ -1,0 +1,10 @@
+- Admin only
+
+# Response
+```
+unresolvedConversationReports: int
+unresolvedSupportTickets: int
+```
+
+# Use
+If the sum of these two values is greater than 0, then display an indicator next to the "Admin Console" link in the nav bar.

--- a/endpoints/POST/GetAuditLogList.md
+++ b/endpoints/POST/GetAuditLogList.md
@@ -1,8 +1,6 @@
-Gets the audit log (supermod only)
-
 # Parameters
-- gameId OR seriesId
-- eventType = ""
+- gameId OR seriesId OR userId OR actorId
+- eventType = #eventType#
 - page
 
 # Response
@@ -15,3 +13,9 @@ auditLogList[]
     gameId
     context
 ```
+
+# Use
+actorId is admin only. But it should be a user's id.
+
+It shows every change that the user has made to something else.
+As opposed to userId, which shows every change that has happened to that user.

--- a/endpoints/POST/GetNotifications.md
+++ b/endpoints/POST/GetNotifications.md
@@ -1,4 +1,4 @@
-Gets this user's notifications
+Gets the user's notifications
 
 # Parameters
 - limit

--- a/endpoints/POST/GetTicketQueueCounts.md
+++ b/endpoints/POST/GetTicketQueueCounts.md
@@ -1,0 +1,12 @@
+- Admin only
+
+# Parameters
+ - status: #Ticket Status#
+
+# Response
+Returns all the ticket queues with the number of tickets with the provided status.
+```
+queueList[]
+	queue: #Ticket Queue#
+	count: int
+```

--- a/endpoints/POST/GetTicketStatusCounts.md
+++ b/endpoints/POST/GetTicketStatusCounts.md
@@ -1,0 +1,12 @@
+- Admin only
+
+# Parameters
+- queue: #Ticket Queue#
+
+# Response
+For a certain queue, for every status, return the amount of tickets that have that status
+```
+statusList[]
+	status: #Ticket Status#
+	count: int
+```

--- a/endpoints/POST/GetTickets.md
+++ b/endpoints/POST/GetTickets.md
@@ -2,10 +2,12 @@ Get support hub tickets.
 
 # Parameters (select one?)
 - queues = []
-- requestorIds = [str] - appears to be necessary?
+- requestorIds = [str] - with this empty, it returns all tickets. Only admins have access, since this is used on their admin console
 - statuses = []
 - ticketIds = [str] - retrieve a specific (set of) ticket(s)
 - types = []
+- page = int - pagination for the admin console
+- limit = int - pagination for the admin console
 
 - page
 
@@ -20,6 +22,13 @@ ticketList[]
     dateSubmitted
     metadata = str (json structure may be per-type)
 ticketNoteList[]
+    id
+    ticketId
+    readerId
+    dateSubmitted
+    note
+    isMessage
+    isRead
 pagination
     count
     page = 1

--- a/endpoints/POST/PutAdvertiseContact.md
+++ b/endpoints/POST/PutAdvertiseContact.md
@@ -1,0 +1,13 @@
+# Parameters
+- name: str
+- company: str
+- email: str
+- message: str
+
+# Response
+```json
+{}
+```
+
+# Use
+For the contact form on the [Partnerships page](https://www.speedrun.com/partnerships#contact)

--- a/endpoints/POST/PutConversationLeave.md
+++ b/endpoints/POST/PutConversationLeave.md
@@ -1,0 +1,6 @@
+# Parameters
+- conversationId
+- csrfToken
+
+# Response
+Undocumented

--- a/endpoints/POST/PutConversationReport.md
+++ b/endpoints/POST/PutConversationReport.md
@@ -1,0 +1,7 @@
+# Parameters
+- conversationId: str
+- csrfToken: str
+- text: str (the report message)
+
+# Response
+Undocumented

--- a/endpoints/POST/PutTicketNote.md
+++ b/endpoints/POST/PutTicketNote.md
@@ -1,0 +1,17 @@
+# Parameters
+- ticketId: str
+- note: str
+- isMessage: Boolean
+
+# Response
+When isMessage is true:
+```
+ok: true
+```
+
+But when isMessage is false, it's a generic 401 unauthorized.
+
+# Use
+When isMessage is true, the admin and user can add messages to communicate in the ticket's conversation.
+
+But when it is set to false, only admins can see their messages in the Admin Console.

--- a/endpoints/enums.md
+++ b/endpoints/enums.md
@@ -7,11 +7,27 @@ Further enums have been implemented in [speedruncompy/enums.py](https://github.c
 ## itemType
 Displayed in various places, including thread comments, (continue)
 ```
-1 = Like? Appears in GetThread.likeList[]
-2 = Run
-7 = Thread comment? Thread?
-27 = Game news post
-30 = Site news post
+Unknown = 0
+Article = 30
+Comment = 1
+Run = 2
+Game = 3
+Guide = 4
+Resource = 5
+User = 6
+Thread = 7
+GameMod = 8
+Category = 9
+Level = 10
+GameRequest = 11
+News = 27
+GameBoostToken = 28
+GameBoost = 29
+Ticket = 22
+TicketNote = 23
+UserFollower = 31
+Challenge = 32
+ChallengeRun = 33
 ```
 
 ## Verified
@@ -183,7 +199,6 @@ NOT the same as ticket type!
 ```
 
 # networkId (in userSocialConnectionList)
-Deprecated values still exist on the site, but are not visible on the website or settable by users anymore
 ```
 3 = Bilibili
 5 = Discord
@@ -193,9 +208,34 @@ Deprecated values still exist on the site, but are not visible on the website or
 18 = Reddit
 29 = Twitch
 30 = Twitter
-31 = Custom URL
+31 = Website
 32 = Youtube
-(deprecated)
+```
+
+Deprecated values are not visible on the website or settable by users anymore
+Deprecated values:
+```
+1 = Askfm
+2 = Battlenet
+4 = Deviantart
+6 = Douyu
+7 = Duolingo
+9 = Googleplus
+10 = Gpodcasts
+12 = Itunes
 13 = Mixer
-22 = splits.io
+14 = Mmrta
+16 = Patreon
+17 = Pinterest
+19 = Smashcast
+20 = Snapchat
+21 = Soundcloud
+22 = Splitsio
+23 = Spotify
+24 = Spotifyshow
+25 = Srl
+26 = Steam
+27 = Stitcher
+28 = Tumblr
+33 = Zsr
 ```


### PR DESCRIPTION
The admin-related endpoints and enums were from me reading the site's code, and from making the frontend think I'm an admin.

The ticket endpoints were used on the site's Admin Console.

There's also some converstation endpoints that said I was unauthenticated when used, so they're undocumented for now.